### PR TITLE
update to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to Selene will be documented in this file.
+
+## [1.0.1] - 2025-08-13
+### Fixed
+- DocumentRoot directory now points to correct Flatpak sandboxed location
+- Contacts directory path corrected for sandboxed environment
+
+## [1.0.0] - 2025-08-13
+### Added
+- Initial release of Selene on Flathub
+- Tor-based peer-to-peer messaging and file sharing
+- End-to-end RSA encryption with multiple key lengths (2048, 4096, 8192 bits)
+- Ephemeral Tor hidden service HTTP file sharing
+- Configurable Tor circuits and ports
+- Contact management with import/export functionality
+- Rich messaging features including emojis and file transfers
+- Advanced logging system and chat history management
+- Password protection at startup
+- Cross-platform Qt interface

--- a/io.github.alamahant.Selene.yml
+++ b/io.github.alamahant.Selene.yml
@@ -32,4 +32,4 @@ modules:
       # Main application source
       - type: git
         url: https://github.com/alamahant/Selene.git
-        tag: v1.0.0
+        tag: v1.0.1


### PR DESCRIPTION
During the initial review process I was suggested to,  to remove  --filesystem=xdg-documents that Selene relied to.Although the local flatpak-builder built with the new manifest --and with sandbox flag on--  seemed able to access the ~/Documents directory to create its files, the official flatpak build from testing repository couldnt.So I needed to do a minor code refactor so that the DocumentRoot dir of the http server and the Contacts dir point to the correct updated sandboxed location. This is what this rather quick update is all about.