### PR TITLE
update to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Selene will be documented in this file.
 
+## [1.0.2] - 2025-08-15
+### Changed
+- Reverted back to using `~/Documents/Selene` as Selene's data location after Flathub graciously granted the `--filesystem=xdg-documents` permission
+- Improved mute/unmute functionality to include the startup welcome tone
+
 ## [1.0.1] - 2025-08-13
 ### Fixed
 - DocumentRoot directory now points to correct Flatpak sandboxed location

--- a/io.github.alamahant.Selene.yml
+++ b/io.github.alamahant.Selene.yml
@@ -11,7 +11,8 @@ finish-args:
   - --socket=pulseaudio
   - --device=dri
   - --share=network
- 
+  - --filesystem=xdg-documents
+
 modules:
   - name: Selene
     buildsystem: cmake-ninja
@@ -32,4 +33,4 @@ modules:
       # Main application source
       - type: git
         url: https://github.com/alamahant/Selene.git
-        tag: v1.0.1
+        tag: v1.0.2


### PR DESCRIPTION
## [1.0.2] - 2025-08-15
### Changed
- Reverted back to using `~/Documents/Selene` as Selene's data location after Flathub graciously granted the `--filesystem=xdg-documents` permission
- Improved mute/unmute functionality to include the startup welcome tone

A kind note to the Reviewers:

Dear reviewers,
 At the time of initial submission of Selene, I had in my manifest --filesystem=xdg-documents.Selene would create a user data folder ~/Documents/Selene where directories www, contacts, and files are created.These are all essential user data directories where the user can access and place files they wish to share, .contact files to import contacts and files to be sent as in-chat messages.
However, wishing to respect flatpak's sandbox rules I willingly removed this permission, resulting in a broken app.
So immediately after publication within one hour I did a quick refactor of the code in order for Selene to point to the new user directories, deep inside ~/.var and updated Selene to v1.0.1
As a result I managed to salvage the application, which is now functional, but VERY user unfriendly:The user needs to perform advanced command line or file manager procedures in order to access and place  their files deep inside ~/.var.
I am letting the user copy these dir locations to clipboard and then open a host file manager to the said locations.But it is frustrating, and diminishes user experience.
Therefore very respectfully I kindly ask the Reviewers to please grant --filesystem=xdg-documents permission to Selene.
I am grateful to you and thanking you for your consideration and understanding.