### PR TITLE
Update to v1-0-2 with narrowed down permissions in the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Selene will be documented in this file.
 
 ## [1.0.2] - 2025-08-15
 ### Changed
-- Reverted back to using `~/Documents/Selene` as Selene's data location after Flathub graciously granted the `--filesystem=xdg-documents` permission
+- Reverted back to using `~/Documents/Selene` as Selene's data location after Flathub graciously granted the `--filesystem=xdg-documents/Selene:create` permission
 - Improved mute/unmute functionality to include the startup welcome tone
 
 ## [1.0.1] - 2025-08-13

--- a/io.github.alamahant.Selene.yml
+++ b/io.github.alamahant.Selene.yml
@@ -11,7 +11,7 @@ finish-args:
   - --socket=pulseaudio
   - --device=dri
   - --share=network
-  - --filesystem=xdg-documents
+  - --filesystem=xdg-documents/Selene:create
 
 modules:
   - name: Selene


### PR DESCRIPTION
Follow-up to merged PR #2 (Merge pull request #2 from flathub/update-to-v1.0.2) which updated Selene to v1.0.2.

Change:

Narrows filesystem permission to:

--filesystem=xdg-documents/Selene:create


This allows Selene to create and access its own folder in ~/Documents/Selene while minimizing broader access.

Note:

Manifest-only update; no app code changes.

I’ll be offline starting Monday for vacation, thus the updated PR.

Thanks for everything.